### PR TITLE
Torsten feature/issue 13 piecewise linear interpolation function

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ SUFIXES:
 # - OS_TYPE: {mac, win, linux}
 # - C++11: Compile with C++11 extensions, Valid values: {true, false}.
 ##
-CC = clang++
+CC = g++
 O = 3
 O_STANC = 0
 AR = ar

--- a/stan/math/prim/arr.hpp
+++ b/stan/math/prim/arr.hpp
@@ -20,6 +20,7 @@
 #include <stan/math/prim/arr/fun/dot_self.hpp>
 #include <stan/math/prim/arr/fun/fill.hpp>
 #include <stan/math/prim/arr/fun/inverse_softmax.hpp>
+#include <stan/math/prim/arr/fun/linear_interpolation.hpp>
 #include <stan/math/prim/arr/fun/log_sum_exp.hpp>
 #include <stan/math/prim/arr/fun/promote_elements.hpp>
 #include <stan/math/prim/arr/fun/promote_scalar.hpp>

--- a/stan/math/prim/arr/fun/linear_interpolation.hpp
+++ b/stan/math/prim/arr/fun/linear_interpolation.hpp
@@ -1,0 +1,78 @@
+#ifndef STAN_MATH_PRIM_ARR_FUN_LINEAR_INTERPOLATION_HPP
+#define STAN_MATH_PRIM_ARR_FUN_LINEAR_INTERPOLATION_HPP
+
+// #include <stan/math/prim/arr/fun/SearchReal.hpp>
+#include <stan/math/torsten/PKModel/SearchReal.hpp>
+#include <vector>
+#include <algorithm>
+
+namespace stan {
+  namespace math {
+
+    /**
+     * Return the values of a piecewise linear function at specifed values of the 
+     * function argument. The function is specified in terms of a set of x y pairs.
+     *
+     * @tparam T0 Type of elements contained in xout array.
+     * @tparam T1 Type of elements contained in y array.
+     * @param xout Scalar or array of function argument values.
+     * @param x Array of x values. Must be in increasing order.
+     * @param y Array of y values. Must have same length as x.
+     * @return Scalar or array of function values.
+     */
+
+    template <typename T0, typename T1, typename T2>
+    typename boost::math::tools::promote_args <T0, T1, T2>::type
+    linear_interpolation(const T0& xout,
+                         const std::vector<T1>& x,
+                         const std::vector<T2>& y) {
+      typedef typename boost::math::tools::promote_args <T0, T1, T2>::type
+        scalar;
+      using std::vector;
+      int nx = x.size();
+      scalar yout;
+
+      check_finite("linear_interpolation", "xout", xout);
+      check_finite("linear_interpolation", "x", x);
+      check_finite("linear_interpolation", "y", y);
+      check_nonzero_size("linear_interpolation", "x", x);
+      check_nonzero_size("linear_interpolation", "y", y);
+      check_ordered("linear_interpolation", "x", x);
+      check_matching_sizes("linear_interpolation", "x", x, "y", y);
+
+      if (xout <= x[0]) {
+        yout = y[0];
+      } else if (xout >= x[nx - 1]) {
+        yout = y[nx - 1];
+      } else {
+        int i = SearchReal(x, nx, xout) - 1;
+        yout = y[i] + (y[i+1] - y[i]) / (x[i+1] - x[i]) * (xout - x[i]);
+      }
+
+      return yout;
+    }
+
+    template <typename T0, typename T1, typename T2>
+    std::vector <typename boost::math::tools::promote_args <T0, T1, T2>::type>
+    linear_interpolation(const std::vector<T0>& xout,
+                         const std::vector<T1>& x,
+                         const std::vector<T2>& y) {
+      typedef typename boost::math::tools::promote_args <T0, T1, T2>::type
+        scalar;
+      using std::vector;
+
+      int nxout = xout.size();
+      vector<scalar> yout(nxout);
+
+      check_nonzero_size("linear_interpolation", "xout", xout);
+      check_finite("linear_interpolation", "xout", xout);
+
+      for (int i = 0; i < nxout; i++) {
+        yout[i] = linear_interpolation(xout[i], x, y);
+      }
+      return yout;
+    }
+
+  }
+}
+#endif

--- a/stan/math/torsten/PKModel/SearchReal.hpp
+++ b/stan/math/torsten/PKModel/SearchReal.hpp
@@ -21,8 +21,8 @@ int min(int a, int b);  // forward declare
  * @return: index of largest value <= srchNum
  *
  */
-template<typename T>
-inline int SearchReal(std::vector<T> v, int numltm, T srchNum) {
+template<typename T0, typename T1>
+inline int SearchReal(std::vector<T0> v, int numltm, T1 srchNum) {
   int first = 0, last, mid, real_limit;
 
   assert(numltm >= 0);

--- a/test/unit/math/prim/arr/fun/linear_interpolation_test.cpp
+++ b/test/unit/math/prim/arr/fun/linear_interpolation_test.cpp
@@ -1,0 +1,252 @@
+#include <stan/math/rev/mat.hpp>
+#include <stan/math/prim/arr.hpp>
+//#include <stan/math/prim/arr/fun/linear_interpolation.hpp>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <test/unit/util.hpp>
+
+TEST(linear_interpolation, linear_example) {
+  int nx = 5, nout = 3;
+  std::vector<double> x(nx), y(nx), xout(nout), yout;
+  double youtTrue;
+
+  for(int i = 0; i < nx; i++){
+    x[i] = i;
+    y[i] = i;
+  }
+
+  xout[0] = 1.5;
+  xout[1] = 2.5;
+  xout[2] = 4.5;
+
+  yout = stan::math::linear_interpolation(xout, x, y);
+  for(int i = 0; i < nout; i++){
+      if(xout[i] <= x[0]){
+	youtTrue = x[0];
+      }else if(xout[i] >= x[nx - 1]){
+	youtTrue = x[nx - 1];
+      }else{
+	youtTrue = xout[i];
+      }
+      EXPECT_FLOAT_EQ(youtTrue, yout[i]);
+  }
+}
+
+TEST(linear_interpolation, xgradient){
+  using stan::math::var;
+  int nx = 5, nout = 3;
+  std::vector<double> xdbl(nx), ydbl(nx), xoutdbl(nout), thisGrad(nx);
+  Eigen::MatrixXd trueJac = Eigen::MatrixXd::Zero(3, 5); 
+
+  for(int i = 0; i < nx; i++){
+    xdbl[i] = i;
+    ydbl[i] = i;
+  }
+
+  xoutdbl[0] = 1.5;
+  xoutdbl[1] = 2.5;
+  xoutdbl[2] = 4.5;
+
+  trueJac(0, 1) = (ydbl[2] - ydbl[1]) * (xoutdbl[0] - xdbl[2]) / pow(xdbl[2] - xdbl[1], 2);
+  trueJac(0, 2) = -(ydbl[2] - ydbl[1]) * (xoutdbl[0] - xdbl[1]) / pow(xdbl[2] - xdbl[1], 2);
+
+  trueJac(1, 2) = (ydbl[3] - ydbl[2]) * (xoutdbl[1] - xdbl[3]) / pow(xdbl[3] - xdbl[2], 2);
+  trueJac(1, 3) = -(ydbl[3] - ydbl[2]) * (xoutdbl[1] - xdbl[2]) / pow(xdbl[3] - xdbl[2], 2);
+
+  for(int i = 0; i < nout; i++){
+    std::vector<var> x(nx), y(nx), xout(nout), yout;
+    for(int k = 0; k < nx; k++){
+      x[k] = k;
+      y[k] = k;
+    }
+    for(int k = 0; k < nout; k++){
+      xout[k] = xoutdbl[k];
+    }
+    yout = stan::math::linear_interpolation(xout, x, y);
+
+    yout[i].grad(x, thisGrad);
+
+    for(int j = 0; j < nx; j++){
+      EXPECT_EQ(trueJac(i, j), thisGrad[j]);
+    }
+  }
+}
+
+TEST(linear_interpolation, ygradient){
+  using stan::math::var;
+  int nx = 5, nout = 3;
+  std::vector<double> xdbl(nx), ydbl(nx), xoutdbl(nout), thisGrad(nx);
+  Eigen::MatrixXd trueJac = Eigen::MatrixXd::Zero(3, 5); 
+
+  for(int i = 0; i < nx; i++){
+    xdbl[i] = i;
+    ydbl[i] = i;
+  }
+
+  xoutdbl[0] = 1.5;
+  xoutdbl[1] = 2.5;
+  xoutdbl[2] = 4.5;
+
+  trueJac(0, 2) = (xoutdbl[0] - xdbl[1]) / (xdbl[2] - xdbl[1]);
+  trueJac(0, 1) = 1 - trueJac(0, 2);
+
+  trueJac(1, 3) = (xoutdbl[1] - xdbl[2]) / (xdbl[3] - xdbl[2]);
+  trueJac(1, 2) = 1 - trueJac(1, 3);
+
+  trueJac(2, 4) = 1;
+
+  for(int i = 0; i < nout; i++){
+    std::vector<var> x(nx), y(nx), xout(nout), yout;
+    for(int k = 0; k < nx; k++){
+      x[k] = k;
+      y[k] = k;
+    }
+    for(int k = 0; k < nout; k++){
+      xout[k] = xoutdbl[k];
+    }
+    yout = stan::math::linear_interpolation(xout, x, y);
+
+    yout[i].grad(y, thisGrad);
+    
+    for(int j = 0; j < nx; j++){
+      EXPECT_EQ(trueJac(i, j), thisGrad[j]);
+    }
+  }
+}
+
+TEST(linear_interpolation, xoutgradient){
+  using stan::math::var;
+  int nx = 5, nout = 3;
+  std::vector<double> xdbl(nx), ydbl(nx), xoutdbl(nout), thisGrad(nx);
+  Eigen::MatrixXd trueJac = Eigen::MatrixXd::Zero(3, 3); 
+
+  for(int i = 0; i < nx; i++){
+    xdbl[i] = i;
+    ydbl[i] = i;
+  }
+
+  xoutdbl[0] = 1.5;
+  xoutdbl[1] = 2.5;
+  xoutdbl[2] = 4.5;
+
+  trueJac(0, 0) = (ydbl[2] - ydbl[1]) / (xdbl[2] - xdbl[1]);
+  trueJac(1, 1) = (ydbl[3] - ydbl[2]) / (xdbl[3] - xdbl[2]);
+
+  for(int i = 0; i < nout; i++){
+    std::vector<var> x(nx), y(nx), xout(nout), yout;
+    for(int k = 0; k < nx; k++){
+      x[k] = k;
+      y[k] = k;
+    }
+    for(int k = 0; k < nout; k++){
+      xout[k] = xoutdbl[k];
+    }
+    yout = stan::math::linear_interpolation(xout, x, y);
+
+    yout[i].grad(xout, thisGrad);
+
+    for(int j = 0; j < nout; j++){
+      EXPECT_EQ(trueJac(i, j), thisGrad[j]);
+    }
+  }
+}
+
+TEST(linear_interpolation, error_conditions) {
+  using stan::math::var;
+  int nx = 5, nout = 3;
+  std::vector<double> x(nx), y(nx), xout(nout), yout;
+
+  for(int i = 0; i < nx; i++){
+    x[i] = i;
+    y[i] = i;
+  }
+
+  xout[0] = 1.5;
+  xout[1] = 2.5;
+  xout[2] = 4.5;
+
+  std::vector<double> xout_bad;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout_bad, x, y),
+                   std::invalid_argument,
+                   "xout has size 0");
+
+  std::vector<double> x_bad;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x_bad, y),
+                   std::invalid_argument,
+                   "x has size 0");
+
+  std::vector<double> y_bad;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x, y_bad),
+                   std::invalid_argument,
+                   "y has size 0");
+
+  std::vector<double> x3_bad = x;
+  x3_bad[2] = 0.0;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x3_bad, y),
+                   std::domain_error,
+                   "x is not a valid ordered vector");
+
+  std::vector<double> x2_bad(nx - 1);  
+  for(int i = 0; i < (nx - 1); i++) x2_bad[i] = x[i];
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x2_bad, y),
+                   std::invalid_argument,
+                   "size of x (4) and size of y (5) must match in size");
+}
+
+TEST(linear_interpolation, error_conditions_inf) {
+  using stan::math::var;
+  std::stringstream expected_is_inf;
+  expected_is_inf << "is " << std::numeric_limits<double>::infinity();
+  std::stringstream expected_is_neg_inf;
+  expected_is_neg_inf << "is " << -std::numeric_limits<double>::infinity();
+  double inf = std::numeric_limits<double>::infinity();
+  int nx = 5, nout = 3;
+  std::vector<double> x(nx), y(nx), xout(nout), yout;
+
+  for(int i = 0; i < nx; i++){
+    x[i] = i;
+    y[i] = i;
+  }
+
+  xout[0] = 1.5;
+  xout[1] = 2.5;
+  xout[2] = 4.5;
+
+  std::vector<double> xout_bad = xout;
+  xout_bad[0] = inf;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout_bad, x, y),
+                   std::domain_error,
+                   "xout");
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout_bad, x, y),
+                   std::domain_error,
+                   expected_is_inf.str());
+
+  xout_bad = xout;
+  xout_bad[0] = -inf;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout_bad, x, y),
+                   std::domain_error,
+                   "xout");
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout_bad, x, y),
+                   std::domain_error,
+                   expected_is_neg_inf.str());
+
+  std::vector<double> x_bad = x;
+  x_bad[0] = inf;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x_bad, y),
+                   std::domain_error,
+                   "x");
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x_bad, y),
+                   std::domain_error,
+                   expected_is_inf.str());
+
+  std::vector<double> y_bad = y;
+  y_bad[0] = -inf;
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x, y_bad),
+                   std::domain_error,
+                   "y");
+  EXPECT_THROW_MSG(stan::math::linear_interpolation(xout, x, y_bad),
+                   std::domain_error,
+                   expected_is_neg_inf.str());
+}


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests: `./runTests.py test/unit`
- [ ] Run cpplint: `make cpplint`
- [ ] Declare copyright holder and open-source license: see below

#### Summary:
The proposed changes add a linear_interpolation function to Stan math and provide code for unit testing

#### Intended Effect:
Provide a Stan language function for piecewise linear interpolation.

#### How to Verify:
Run unit tests. In addition a working example called testInterp2.rmd is provided in the example-models repo.

#### Side Effects:

#### Documentation:
linear_interpolation is documented in the Torsten Users Manual

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Metrum Research Group

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
