### PR TITLE
comment out Marker() function in Torsten to avoid global variable.

### DIFF
--- a/stan/math/torsten/PKModel/functions.hpp
+++ b/stan/math/torsten/PKModel/functions.hpp
@@ -3,6 +3,7 @@
 // FIX ME: deprecate the print functions.
 // FIX ME: each function should have its own header file
 // FIX ME: using statements should be inside the scope of functions
+// FIX ME: using functor for Marker instead of function with global variable
 
 #ifndef STAN_MATH_TORSTEN_PKMODEL_FUNCTIONS_HPP
 #define STAN_MATH_TORSTEN_PKMODEL_FUNCTIONS_HPP
@@ -22,13 +23,13 @@
  */
 
 ////////// FOR DEVELOPMENT PURPOSES //////////////
-int marker_count = 0;  // define global variable
-inline void Marker() {
-  std::cout << "MARKER "
-            << marker_count
-            << std::endl;
-  marker_count++;
-}
+// int marker_count = 0;  // define global variable
+// inline void Marker() {
+//   std::cout << "MARKER "
+//             << marker_count
+//             << std::endl;
+//   marker_count++;
+// }
 
 ////////// REQUIRED FOR TORSTEN //////////////
 template<typename T>


### PR DESCRIPTION
This global variable causes unit test building failure (bug #18)

#### Submission Checklist

- [x] Run unit tests: `./runTests.py test/unit`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Remove global variable to avoid make failure of multiple_translation_units_test
#### Intended Effect:
N/A
#### How to Verify:
> make -j1 multiple_translation_units_test

#### Side Effects:
N/A

#### Copyright and Licensing
This prototype is still under development and has been uploaded to facilitate working with the community of Stan developers. The current version was written by Charles Margossian (@charlesm93), Bill Gillespie (@billgillespie), Yi Zhang(@yizhang-cae), and Metrum Research Group, LLC. We have recieved extensive help from the Stan development team.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
