### PR TITLE
Bugfix issue 15 ii grad

### DIFF
--- a/stan/math/torsten/event_history.hpp
+++ b/stan/math/torsten/event_history.hpp
@@ -21,7 +21,7 @@ namespace torsten {
   struct EventHistory {
     using T4 = typename stan::math::value_type<T4_container>::type;
     using T_scalar = typename torsten::return_t<T0, T1, T2, T3, T4, T5, T6>::type;
-    using T_time = typename torsten::return_t<T0, T1, T6, T2>::type;
+    using T_time = typename torsten::return_t<T0, T1, T3, T6, T2>::type;
     using T_rate = typename torsten::return_t<T2, T5>::type;
     using T_amt = typename torsten::return_t<T1, T5>::type;
     using Param = std::pair<double, std::array<int, 3> >;

--- a/stan/math/torsten/events_record.hpp
+++ b/stan/math/torsten/events_record.hpp
@@ -27,7 +27,7 @@ template <typename T0, typename T1, typename T2, typename T3, typename T4_contai
 struct NONMENEventsRecord {
   using T4 = typename stan::math::value_type<T4_container>::type;
   using T_scalar = typename torsten::return_t<T0, T1, T2, T3, T4, T5, T6>::type;
-  using T_time = typename torsten::return_t<T0, T1, T6, T2>::type;
+  using T_time = typename torsten::return_t<T0, T1, T3, T6, T2>::type;
   using T_rate = typename torsten::return_t<T2, T5>::type;
   using T_amt = typename torsten::return_t<T1, T5>::type;
   using T_par = T4;

--- a/stan/math/torsten/finite_diff_gradient.hpp
+++ b/stan/math/torsten/finite_diff_gradient.hpp
@@ -1,0 +1,97 @@
+#ifndef STAN_MATH_TORSTEN_FINITE_DIFF_GRADIENT_HPP
+#define STAN_MATH_TORSTEN_FINITE_DIFF_GRADIENT_HPP
+
+#include <stan/math/prim/mat/fun/Eigen.hpp>
+
+namespace torsten {
+
+/**
+ * Calculate the value and the gradient of the specified function
+ * at the specified argument using finite difference.
+ *
+ * <p>The functor must implement
+ *
+ * <code>
+ * double
+ * operator()(const
+ * Eigen::Matrix<double, Eigen::Dynamic, 1>&)
+ * </code>
+ *
+ * Error should be on order of epsilon ^ 6.
+ * The reference for this algorithm is:
+ *
+ * De Levie: An improved numerical approximation
+ * for the first derivative, page 3
+ *
+ * This function involves 6 calls to f.
+ *
+ * @tparam F Type of function
+ * @param[in] f Function that returns a scalar
+ * @param[in] x Argument to function
+ * @param[out] fx Function applied to argument
+ * @param[out] grad_fx Gradient of function at argument
+ * @param[in] epsilon perturbation size
+ */
+template <typename F>
+auto finite_diff_gradient(const F& f, const std::vector<double>& x,
+                          double epsilon = 1e-03) {
+  std::vector<double> x_temp(x);
+
+  int d = x.size();
+  using scalar_t = typename std::decay<decltype(f(x))>::type;
+  std::vector<scalar_t> grad_fx(d);
+
+  for (int i = 0; i < d; ++i) {
+    scalar_t delta_f = 0.0;
+
+    x_temp[i] = x[i] + 3.0 * epsilon;
+    delta_f = f(x_temp);
+
+    x_temp[i] = x[i] + 2.0 * epsilon;
+    delta_f -= 9.0 * f(x_temp);
+
+    x_temp[i] = x[i] + epsilon;
+    delta_f += 45.0 * f(x_temp);
+
+    x_temp[i] = x[i] + -3.0 * epsilon;
+    delta_f -= f(x_temp);
+
+    x_temp[i] = x[i] + -2.0 * epsilon;
+    delta_f += 9.0 * f(x_temp);
+
+    x_temp[i] = x[i] + -epsilon;
+    delta_f -= 45.0 * f(x_temp);
+
+    delta_f /= 60 * epsilon;
+
+    x_temp[i] = x[i];
+    grad_fx[i] = delta_f;
+  }
+  return grad_fx;
+}
+
+  template<typename T>
+  inline const T& ith_of(const std::vector<T, T>&& d, int i) {
+    return d.at(i);
+  }
+
+  template<typename T, int R, int C>
+  inline const T& ith_of(const Eigen::Matrix<T, R, C>&& d, int i) {
+    return d(i);
+  }
+
+  /*
+   * @param[in] f Function that returns a vector
+   */
+template <typename F>
+auto finite_diff_gradient(const F& f, const std::vector<double>& x, int k,
+                          double epsilon = 1e-03) {
+  auto f1 = [&f, &k](const std::vector<double>& x) {
+    return ith_of(f(x), k);
+  };
+
+  return finite_diff_gradient(f1, x, epsilon);
+}
+
+}  // namespace torsten
+#endif

--- a/stan/math/torsten/pmx_ode_integrator.hpp
+++ b/stan/math/torsten/pmx_ode_integrator.hpp
@@ -29,6 +29,34 @@ namespace torsten {
   using torsten::pmx_integrate_ode_bdf;
   using torsten::pmx_integrate_ode_rk45;
 
+#define DEF_STAN_INTEGRATOR(INT_NAME)                                                 \
+  template <typename F, typename Tt, typename T_initial, typename T_param>            \
+  std::vector<std::vector<typename torsten::return_t<Tt, T_initial, T_param>::type> > \
+  operator()(const F& f,                                                              \
+             const std::vector<T_initial>& y0,                                        \
+             double t0,                                                               \
+             const std::vector<Tt>& ts,                                               \
+             const std::vector<T_param>& theta,                                       \
+             const std::vector<double>& x_r,                                          \
+             const std::vector<int>& x_i) const {                                     \
+    std::vector<double> ts_dbl(stan::math::value_of(ts));                             \
+    return INT_NAME(f, y0, t0, ts, theta, x_r, x_i, msgs, rtol, atol, max_num_step);  \
+  }
+
+#define DEF_STAN_SINGLE_STEP_INTEGRATOR                                               \
+  template <typename F, typename Tt, typename T_initial, typename T_param>            \
+  std::vector<std::vector<typename torsten::return_t<Tt, T_initial, T_param>::type> > \
+  operator()(const F& f,                                                              \
+             const std::vector<T_initial>& y0,                                        \
+             double t0,                                                               \
+             const Tt& t1,                                                            \
+             const std::vector<T_param>& theta,                                       \
+             const std::vector<double>& x_r,                                          \
+             const std::vector<int>& x_i) const {                                     \
+    std::vector<double> ts{stan::math::value_of(t1)};                                 \
+    return (*this)(f, y0, t0, ts, theta, x_r, x_i);                                   \
+  }
+
 #define DEF_TORSTEN_INTEGRATOR(INT_NAME)                                              \
   template <typename F, typename Tt, typename T_initial, typename T_param>            \
   std::vector<std::vector<typename torsten::return_t<Tt, T_initial, T_param>::type> > \
@@ -84,8 +112,8 @@ namespace torsten {
       rtol(rtol0), atol(atol0), max_num_step(max_num_step0), msgs(msgs0)
     {}
     
-    DEF_TORSTEN_INTEGRATOR(integrate_ode_adams)
-    DEF_TORSTEN_SINGLE_STEP_INTEGRATOR
+    DEF_STAN_INTEGRATOR(integrate_ode_adams)
+    DEF_STAN_SINGLE_STEP_INTEGRATOR
   };
 
   template<>
@@ -102,8 +130,8 @@ namespace torsten {
       rtol(rtol0), atol(atol0), max_num_step(max_num_step0), msgs(msgs0)
     {}
     
-    DEF_TORSTEN_INTEGRATOR(integrate_ode_bdf)
-    DEF_TORSTEN_SINGLE_STEP_INTEGRATOR
+    DEF_STAN_INTEGRATOR(integrate_ode_bdf)
+    DEF_STAN_SINGLE_STEP_INTEGRATOR
   };
 
   template<>
@@ -120,8 +148,8 @@ namespace torsten {
       rtol(rtol0), atol(atol0), max_num_step(max_num_step0), msgs(msgs0)
     {}
     
-    DEF_TORSTEN_INTEGRATOR(integrate_ode_rk45)
-    DEF_TORSTEN_SINGLE_STEP_INTEGRATOR
+    DEF_STAN_INTEGRATOR(integrate_ode_rk45)
+    DEF_STAN_SINGLE_STEP_INTEGRATOR
   };
 
   /*

--- a/stan/math/torsten/pmx_ode_model.hpp
+++ b/stan/math/torsten/pmx_ode_model.hpp
@@ -192,7 +192,6 @@ namespace refactor {
 
       double t0 = 0;
       double ii_ = x_r[0];
-      const vector<double> ts{ii_};
 
       vector<scalar_t> x0(x.size());
       for (size_t i = 0; i < x0.size(); i++) x0[i] = x(i);
@@ -207,20 +206,20 @@ namespace refactor {
 
       if (rate == 0) {  // bolus dose
         x0[cmt_ - 1] += amt;
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, theta, x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, ii_, theta, x_r, x_i)[0];
         for (int i = 0; i < result.size(); i++) {
           result(i) = x(i) - pred[i];
         }
       } else if (ii_ > 0) {  // multiple truncated infusions
-        std::vector<T1> ts_v{amt / rate};
+        T1 dt = amt / rate;
 
-        torsten::check_mti(amt, ts_v[0], ii_, function);
+        torsten::check_mti(amt, dt, ii_, function);
 
-        x0 = integrator_(f_, to_array_1d(x), t0, ts_v, theta, x_r, x_i)[0];
+        x0 = integrator_(f_, to_array_1d(x), t0, dt, theta, x_r, x_i)[0];
 
-        ts_v[0] = ii_ - ts_v[0];
+        dt = ii_ - dt;
         theta[npar_ + cmt_ - 1] = 0.0;
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts_v, theta, x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, dt, theta, x_r, x_i)[0];
         for (int i = 0; i < result.size(); i++) result(i) = x(i) - pred[i];
       } else {  // constant infusion
         stan::math::check_less_or_equal(function, "AMT", amt, 0);
@@ -296,7 +295,6 @@ namespace refactor {
       double ii_ = x_r.back();
       double amt = x_r.rbegin()[1];
       double rate = x_r[cmt_ - 1];
-      vector<double> ts(1);
 
       vector<scalar_t> x0(x.size());
       for (size_t i = 0; i < x0.size(); i++) x0[i] = x(i);
@@ -307,24 +305,23 @@ namespace refactor {
 
       if (rate == 0) {  // bolus dose
         x0[cmt_ - 1] += amt;
-        ts[0] = ii_;
 
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, to_array_1d(y), x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, ii_, to_array_1d(y), x_r, x_i)[0];
 
         for (int i = 0; i < result.size(); i++)
           result(i) = x(i) - pred[i];
 
       } else if (ii_ > 0) {  // multiple truncated infusions
-        ts[0] = amt / rate;
+        double dt = amt / rate;
 
-        torsten::check_mti(amt, ts[0], ii_, function);
+        torsten::check_mti(amt, dt, ii_, function);
 
         std::vector<T1> theta = to_array_1d(y);
-        x0 = integrator_(f_, to_array_1d(x), t0, ts, theta, x_r, x_i)[0];
+        x0 = integrator_(f_, to_array_1d(x), t0, dt, theta, x_r, x_i)[0];
 
-        ts[0] = ii_ - ts[0];
+        dt = ii_ - dt;
         std::vector<double> null_rate(x_r.size() - 1, 0.0);
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, theta, null_rate, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, dt, theta, null_rate, x_i)[0];
 
         for (int i = 0; i < result.size(); i++)
           result(i) = x(i) - pred[i];
@@ -416,20 +413,18 @@ namespace refactor {
 
       if (rate == 0) {  // bolus dose
         x0[cmt_ - 1] += amt;
-        vector<T1> ts{ii_};
-
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, ode_parameters, x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, ii_, ode_parameters, x_r, x_i)[0];
 
         for (int i = 0; i < result.size(); i++)
           result(i) = x(i) - pred[i];
 
       } else if (ii_ > 0) {  // multiple truncated infusions
-        vector<T1> ts{amt / rate};
-        torsten::check_mti(amt, ts[0], ii_, function);
-        x0 = integrator_(f_, to_array_1d(x), t0, ts, ode_parameters, x_r, x_i)[0];
-        ts[0] = ii_ - ts[0];
+        T1 dt = amt / rate;
+        torsten::check_mti(amt, dt, ii_, function);
+        x0 = integrator_(f_, to_array_1d(x), t0, dt, ode_parameters, x_r, x_i)[0];
+        dt = ii_ - dt;
         std::vector<double> null_rate(ncmt_, 0.0);
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, ode_parameters, null_rate, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, dt, ode_parameters, null_rate, x_i)[0];
         for (int i = 0; i < result.size(); i++) {
           result(i) = x(i) - pred[i];          
         }
@@ -510,7 +505,6 @@ namespace refactor {
       double ii_ = x_r.back();
       const T1& amt = y(y.size() - 1);
       double rate = x_r.at(cmt_ - 1);
-      const vector<double> ts{ii_};
 
       vector<scalar_t> x0(x.size());
       for (size_t i = 0; i < x0.size(); i++) x0[i] = x(i);
@@ -523,21 +517,21 @@ namespace refactor {
 
       if (rate == 0) {  // bolus dose
         x0[cmt_ - 1] += amt;
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, theta, x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, ii_, theta, x_r, x_i)[0];
 
         for (int i = 0; i < result.size(); i++) {
           result(i) = x(i) - pred[i];        
         }
       } else if (ii_ > 0) {  // multiple truncated infusions
-        std::vector<T1> ts_v{amt / rate};
+        T1 dt = amt / rate;
 
-        torsten::check_mti(amt, ts_v[0], ii_, function);
+        torsten::check_mti(amt, dt, ii_, function);
       
-        x0 = integrator_(f_, to_array_1d(x), t0, ts_v, theta, x_r, x_i)[0];
+        x0 = integrator_(f_, to_array_1d(x), t0, dt, theta, x_r, x_i)[0];
 
-        ts_v[0] = ii_ - ts_v[0];
+        dt = ii_ - dt;
         std::vector<double> null_rate(x_r.size(), 0.0);
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts_v, theta, null_rate, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, dt, theta, null_rate, x_i)[0];
 
         for (int i = 0; i < result.size(); i++) result(i) = x(i) - pred[i];
       } else {  // constant infusion
@@ -613,7 +607,6 @@ namespace refactor {
       double ii_ = x_r.back();
       const double amt = x_r.front();
       const T1& rate = y(npar_ + cmt_ - 1);
-      const vector<double> ts{ii_};
 
       vector<scalar_t> x0(x.size());
       for (size_t i = 0; i < x0.size(); i++) x0[i] = x(i);
@@ -624,20 +617,20 @@ namespace refactor {
 
       if (rate == 0) {  // bolus dose
         x0[cmt_ - 1] += amt;
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts, theta, x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, ii_, theta, x_r, x_i)[0];
         for (int i = 0; i < result.size(); i++) {
           result(i) = x(i) - pred[i];        
         }
       } else if (ii_ > 0) {  // multiple truncated infusions
-        std::vector<T1> ts_v{amt / rate};
+        T1 dt = amt / rate;
 
-        torsten::check_mti(amt, ts_v[0], ii_, function);
+        torsten::check_mti(amt, dt, ii_, function);
       
-        x0 = integrator_(f_, to_array_1d(x), t0, ts_v, theta, x_r, x_i)[0];
+        x0 = integrator_(f_, to_array_1d(x), t0, dt, theta, x_r, x_i)[0];
 
-        ts_v[0] = ii_ - ts_v[0];
+        dt = ii_ - dt;
         theta[npar_ + cmt_ - 1] = 0.0;
-        vector<scalar_t> pred = integrator_(f_, x0, t0, ts_v, theta, x_r, x_i)[0];
+        vector<scalar_t> pred = integrator_(f_, x0, t0, dt, theta, x_r, x_i)[0];
         for (int i = 0; i < result.size(); i++) result(i) = x(i) - pred[i];
       } else {  // constant infusion
         stan::math::check_less_or_equal(function, "AMT", amt, 0);

--- a/test/unit/math/torsten/dsolve/pmx_cvodes_integrator_test.cpp
+++ b/test/unit/math/torsten/dsolve/pmx_cvodes_integrator_test.cpp
@@ -31,14 +31,14 @@ TEST_F(TorstenOdeTest_sho, t0_var) {
   std::vector<double> t0_vec{t0};
   
   {
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       auto y = torsten::pmx_integrate_ode_bdf(f, y0, x[0], ts, theta , x_r, x_i);
       Eigen::MatrixXd y1(1, 2);
       y1(0) = y[0][0];
       y1(1) = y[0][1];
       return y1;
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       double t0 = stan::math::value_of(x[0]);
       std::vector<var> ts_v{t0 + ts[0] - x[0]};
       auto y = torsten::pmx_integrate_ode_bdf(f, y0, t0, ts_v, theta , x_r, x_i);
@@ -58,7 +58,7 @@ TEST_F(TorstenOdeTest_chem, t0_var) {
   std::vector<double> t0_vec{t0};
   
   {
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       auto y = torsten::pmx_integrate_ode_bdf(f, y0, x[0], ts, theta , x_r, x_i);
       Eigen::MatrixXd y1(1, 3);
       y1(0) = y[0][0];
@@ -66,7 +66,7 @@ TEST_F(TorstenOdeTest_chem, t0_var) {
       y1(2) = y[0][2];
       return y1;
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       double t0 = stan::math::value_of(x[0]);
       std::vector<var> ts_v{t0 + ts[0] - x[0]};
       auto y = torsten::pmx_integrate_ode_bdf(f, y0, t0, ts_v, theta , x_r, x_i);
@@ -87,7 +87,7 @@ TEST_F(TorstenOdeTest_lorenz, t0_var) {
   std::vector<double> t0_vec{t0};
   
   {
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       auto y = torsten::pmx_integrate_ode_bdf(f, y0, x[0], ts, theta , x_r, x_i);
       Eigen::MatrixXd y1(1, 3);
       y1(0) = y[0][0];
@@ -95,7 +95,7 @@ TEST_F(TorstenOdeTest_lorenz, t0_var) {
       y1(2) = y[0][2];
       return y1;
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       double t0 = stan::math::value_of(x[0]);
       std::vector<var> ts_v{t0 + ts[0] - x[0]};
       auto y = torsten::pmx_integrate_ode_bdf(f, y0, t0, ts_v, theta , x_r, x_i);

--- a/test/unit/math/torsten/pmx_ode_solver_integrator_test.cpp
+++ b/test/unit/math/torsten/pmx_ode_solver_integrator_test.cpp
@@ -28,11 +28,11 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_t0_var) {
 
   {
     PMXOdeIntegrator<PkBdf> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       model1_t model(x[0], y0, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       model2_t model(x[0], y0, rate, model0.par(), model0.f());
       return model.solve(t1_v, integ);
     };
@@ -42,11 +42,11 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_t0_var) {
 
   {
     PMXOdeIntegrator<PkAdams> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       model1_t model(x[0], y0, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       model2_t model(x[0], y0, rate, model0.par(), model0.f());
       return model.solve(t1_v, integ);
     };
@@ -76,13 +76,13 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_rate_t0_var) {
 
   {
     PMXOdeIntegrator<PkBdf> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       double t0 = x[0];
       std::vector<double> rate1(x.begin() + 1, x.end());
       model1_t model(t0, y0, rate1, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       var t0 = x[0];
       std::vector<var> rate1(x.begin() + 1, x.end());
       model2_t model(t0, y0, rate1, model0.par(), model0.f());
@@ -94,13 +94,13 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_rate_t0_var) {
 
   {
     PMXOdeIntegrator<PkAdams> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       double t0 = x[0];
       std::vector<double> rate1(x.begin() + 1, x.end());
       model1_t model(t0, y0, rate1, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       var t0 = x[0];
       std::vector<var> rate1(x.begin() + 1, x.end());
       model2_t model(t0, y0, rate1, model0.par(), model0.f());
@@ -136,11 +136,11 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_ts_var) {
 
   {
     PMXOdeIntegrator<PkBdf> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       model1_t model(t0, y0, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       model2_t model(t0_v, y0_v, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
@@ -149,11 +149,11 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_ts_var) {
 
   {
     PMXOdeIntegrator<PkBdf> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       model1_t model(t0, y0, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       model3_t model(t0_v, y0, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
@@ -162,11 +162,11 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_ts_var) {
 
   {
     PMXOdeIntegrator<PkAdams> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       model1_t model(t0, y0, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       model2_t model(t0_v, y0_v, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
@@ -175,11 +175,11 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_ts_var) {
 
   {
     PMXOdeIntegrator<PkAdams> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       model1_t model(t0, y0, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       model3_t model(t0_v, y0, rate, model0.par(), model0.f());
       return model.solve(x[0], integ);
     };
@@ -212,12 +212,12 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_y0_var) {
 
   {
     PMXOdeIntegrator<PkBdf> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       refactor::PKRec<double> xr = stan::math::to_vector(x);
       model1_t model(t0, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       refactor::PKRec<var> xr = stan::math::to_vector(x);
       model2_t model(t0, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
@@ -227,12 +227,12 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_y0_var) {
 
   {
     PMXOdeIntegrator<PkBdf> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       refactor::PKRec<double> xr = stan::math::to_vector(x);
       model1_t model(t0, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       refactor::PKRec<var> xr = stan::math::to_vector(x);
       model3_t model(t0_v, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
@@ -242,12 +242,12 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_y0_var) {
 
   {
     PMXOdeIntegrator<PkAdams> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       refactor::PKRec<double> xr = stan::math::to_vector(x);
       model1_t model(t0, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       refactor::PKRec<var> xr = stan::math::to_vector(x);
       model2_t model(t0, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
@@ -257,12 +257,12 @@ TEST_F(TorstenTwoCptModelTest, pk_integrator_y0_var) {
 
   {
     PMXOdeIntegrator<PkAdams> integ(rtol, atol, max_num_steps, msgs);
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       refactor::PKRec<double> xr = stan::math::to_vector(x);
       model1_t model(t0, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
     };
-    auto f2 = [&] (std::vector<var>& x) {
+    auto f2 = [&] (const std::vector<var>& x) {
       refactor::PKRec<var> xr = stan::math::to_vector(x);
       model3_t model(t0_v, xr, rate, model0.par(), model0.f());
       return model.solve(t1, integ);
@@ -292,8 +292,8 @@ TEST_F(TorstenTwoCptModelTest, pk_bdf_integrator_dt_var) {
 
   std::vector<double> dtv{ts[0]};
   {
-    auto f1 = [&] (std::vector<double>& x) { return model1.solve(x[0], integ); };
-    auto f2 = [&] (std::vector<var>& x) { return model2.solve(x[0], integ); };
+    auto f1 = [&] (const std::vector<double>& x) { return model1.solve(x[0], integ); };
+    auto f2 = [&] (const std::vector<var>& x) { return model2.solve(x[0], integ); };
     torsten::test::test_grad(f1, f2, dtv, 2e-5, 1e-6, 1e-3, 1e-3);
   }
 }
@@ -319,8 +319,8 @@ TEST_F(TorstenTwoCptModelTest, pk_adams_integrator_dt_var) {
 
   std::vector<double> dtv{ts[0]};
   {
-    auto f1 = [&] (std::vector<double>& x) { return model1.solve(x[0], integ); };
-    auto f2 = [&] (std::vector<var>& x) { return model2.solve(x[0], integ); };
+    auto f1 = [&] (const std::vector<double>& x) { return model1.solve(x[0], integ); };
+    auto f2 = [&] (const std::vector<var>& x) { return model2.solve(x[0], integ); };
     torsten::test::test_grad(f1, f2, dtv, 2e-5, 1e-6, 1e-3, 1e-4);
   }
 }

--- a/test/unit/math/torsten/pmx_ode_test.cpp
+++ b/test/unit/math/torsten/pmx_ode_test.cpp
@@ -1463,3 +1463,259 @@ TEST_F(TorstenTwoCptTest, ss_multiple_infusion_amt_rate) {
                             rel_tol, abs_tol, max_num_steps,
                             2e-5, 1e-6, 1e-3, 1e-5);
 }
+
+TEST_F(TorstenTwoCptTest, multiple_infusion_ii_amt_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  time[3] = 7.0;
+  resize(4);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  rate[0] = 530;
+  rate[1] = 749;
+  addl[0] = 2;
+  addl[1] = 2;
+  addl[2] = 1;
+  ii[0] = 0.4;
+  ii[1] = 0.6;
+  ii[2] = 0.7;
+  ii[3] = 0.7;
+  ss[0] = 0;
+  ss[1] = 0;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                           time, amt_var, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_infusion_ii_amt_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  time[3] = 10.0;
+  resize(4);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  rate[0] = 530;
+  rate[1] = 749;
+  addl[0] = 0;
+  addl[1] = 0;
+  addl[2] = 0;
+  ii[0] = 2.4;
+  ii[1] = 2.6;
+  ii[2] = 2.7;
+  ii[3] = 2.7;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                           time, amt_var, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, multiple_bolus_ii_amt_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  time[3] = 7.0;
+  resize(4);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  addl[0] = 2;
+  addl[1] = 2;
+  addl[2] = 1;
+  ii[0] = 1.0;
+  ii[1] = 2.0;
+  ii[2] = 3.0;
+  ii[3] = 1.0;
+  ss[0] = 0;
+  ss[1] = 0;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                           time, amt_var, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_bolus_ii_amt_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  resize(3);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  addl[0] = 0;
+  addl[1] = 0;
+  addl[2] = 0;
+  ii[0] = 1.0;
+  ii[1] = 2.0;
+  ii[2] = 3.0;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_rk45, f_twocpt, nCmt,
+                           time, amt_var, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_infusion_ii_amt) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  time[3] = 10.0;
+  resize(4);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  rate[0] = 530;
+  rate[1] = 749;
+  addl[0] = 0;
+  addl[1] = 0;
+  addl[2] = 0;
+  ii[0] = 2.4;
+  ii[1] = 2.6;
+  ii[2] = 2.7;
+  ii[3] = 2.7;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                           time, amt_var, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_bolus_ii_amt) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  resize(3);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  addl[0] = 0;
+  addl[1] = 0;
+  addl[2] = 0;
+  ii[0] = 1.0;
+  ii[1] = 2.0;
+  ii[2] = 3.0;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_rk45, f_twocpt, nCmt,
+                           time, amt_var, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_infusion_ii_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  time[3] = 10.0;
+  resize(4);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  rate[0] = 530;
+  rate[1] = 749;
+  addl[0] = 0;
+  addl[1] = 0;
+  addl[2] = 0;
+  ii[0] = 2.4;
+  ii[1] = 2.6;
+  ii[2] = 2.7;
+  ii[3] = 2.7;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                           time, amt, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_bolus_ii_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 6.0;
+  resize(3);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 900;
+  addl[0] = 0;
+  addl[1] = 0;
+  addl[2] = 0;
+  ii[0] = 1.0;
+  ii[1] = 2.0;
+  ii[2] = 3.0;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<stan::math::var> amt_var(amt.begin(), amt.end());
+  std::vector<stan::math::var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_rk45, f_twocpt, nCmt,
+                           time, amt, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-5, 1e-6);
+}

--- a/test/unit/math/torsten/pmx_ode_test.cpp
+++ b/test/unit/math/torsten/pmx_ode_test.cpp
@@ -1357,7 +1357,7 @@ TEST_F(TorstenOneCptTest, ss_multiple_bolus_time) {
   TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
-                              2e-5, 1e-6, 1e-5, 8e-5);
+                              2e-5, 1e-6, 1e-5, 9e-5);
 }
 
 TEST_F(TorstenOneCptTest, ss_multiple_bolus_ii) {

--- a/test/unit/math/torsten/pmx_ode_test.cpp
+++ b/test/unit/math/torsten/pmx_ode_test.cpp
@@ -1268,13 +1268,10 @@ TEST_F(TorstenOneCptTest, multiple_infusion_time) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  std::vector<var> time_var(time.begin(), time.end());
-
   TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
-
 }
 
 TEST_F(TorstenOneCptTest, multiple_bolus_time) {
@@ -1295,8 +1292,6 @@ TEST_F(TorstenOneCptTest, multiple_bolus_time) {
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-
-  std::vector<var> time_var(time.begin(), time.end());
 
   TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
@@ -1327,8 +1322,6 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_time) {
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-
-  std::vector<var> time_var(time.begin(), time.end());
 
   TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
@@ -1361,10 +1354,33 @@ TEST_F(TorstenOneCptTest, ss_multiple_bolus_time) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  std::vector<var> time_var(time.begin(), time.end());
-
   TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 8e-5);
+}
+
+TEST_F(TorstenOneCptTest, ss_multiple_bolus_ii) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  resize(2);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  rate[0] = 0;
+  rate[1] = 0;
+  addl[0] = 2;
+  addl[1] = 0;
+  ii[0] = 1.4;
+  ii[1] = 0.7;
+  ss[0] = 1;
+  ss[1] = 0;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_bdf, f, nCmt,
+                           time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                           rel_tol, abs_tol, max_num_steps,
+                           2e-5, 1e-6, 1e-6, 1e-8);
 }

--- a/test/unit/math/torsten/pmx_ode_test.cpp
+++ b/test/unit/math/torsten/pmx_ode_test.cpp
@@ -13,8 +13,8 @@
 #include <test/unit/math/torsten/util_generalOdeModel.hpp>
 #include <gtest/gtest.h>
 
-auto f  = refactor::PMXOneCptModel<double,double,double,double>::f_;
-auto f2 = refactor::PMXTwoCptModel<double,double,double,double>::f_;
+auto f_onecpt = refactor::PMXOneCptModel<double,double,double,double>::f_;
+auto f_twocpt = refactor::PMXTwoCptModel<double,double,double,double>::f_;
 
 using stan::math::var;
 using std::vector;
@@ -44,13 +44,13 @@ TEST_F(TorstenOneCptTest, ss_zero_rate) {
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f, nCmt,
+  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f_onecpt, nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
                                 0,
                                 rel_tol, abs_tol, max_num_steps);
 
-  MatrixXd x_bdf = torsten::pmx_solve_bdf(f, nCmt,
+  MatrixXd x_bdf = torsten::pmx_solve_bdf(f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
                               pMatrix, biovar, tlag,
                               0,
@@ -72,32 +72,32 @@ TEST_F(TorstenOneCptTest, ss_zero_rate) {
   torsten::test::test_val(x_rk45, xt, 1e-6, 1e-4);
   torsten::test::test_val(x_bdf, xt, 1e-4, 1e-4);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 5e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-4, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-6);
@@ -125,12 +125,12 @@ TEST_F(TorstenOneCptTest, single_bolus_tlag) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-10, 1e-4, 1e-5);
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-10, 1e-4, 1e-5);
@@ -165,12 +165,12 @@ TEST_F(TorstenOneCptTest, multiple_bolus_tlag) {
   double rel_tol = 1e-10, abs_tol = 1e-10;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-10, 1e-4, 1e-5);
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-7, 1e-4, 1e-5);
@@ -200,12 +200,12 @@ TEST_F(TorstenOneCptTest, single_iv_tlag) {
   double rel_tol = 1e-10, abs_tol = 1e-10;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-9, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-8, 1e-6, 1e-6);
@@ -244,12 +244,12 @@ TEST_F(TorstenOneCptTest, multiple_iv_tlag) {
   double rel_tol = 1e-10, abs_tol = 1e-10;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-5, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_TLAG_TEST(pmx_solve_adams, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-7, 1e-6, 1e-6);
@@ -287,7 +287,7 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_tlag) {
   long int max_num_steps = 1e8;
 
   {
-    auto f1 = [&] (std::vector<double>& x) {
+    auto f1 = [&] (const std::vector<double>& x) {
       std::vector<std::vector<double> > tlag1(nt);
       for (int i = 0; i < nt; ++i) tlag1[i] = tlag[i];
       tlag1[3] = x;
@@ -295,10 +295,10 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_tlag) {
       events_rec(nCmt, time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag1);
       torsten::EventsManager<NONMENEventsRecord<double, double, double, double, std::vector<double>, double, double>>
       em(events_rec);
-      return torsten::pmx_solve_bdf(f, nCmt, time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag1,
+      return torsten::pmx_solve_bdf(f_onecpt, nCmt, time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag1,
                                           0, rel_tol, abs_tol, max_num_steps);
     };
-    auto f2 = [&] (std::vector<stan::math::var>& x) {
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {
       std::vector<std::vector<var> > tlag1(nt);
       for (int i = 0; i < nt; ++i) tlag1[i] = stan::math::to_var(tlag[i]);
       tlag1[3] = x;
@@ -306,7 +306,7 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_tlag) {
       events_rec(nCmt, time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag1);
       torsten::EventsManager<NONMENEventsRecord<double, double, double, double, std::vector<double>, double, var>>
       em(events_rec);
-      return torsten::pmx_solve_bdf(f, nCmt, time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag1,
+      return torsten::pmx_solve_bdf(f_onecpt, nCmt, time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag1,
                                           0, rel_tol, abs_tol, max_num_steps);
     };
     std::vector<double> tlag_test(tlag[3]);
@@ -330,32 +330,32 @@ TEST_F(TorstenOneCptTest, ss_bolus) {
   biovar[0] = std::vector<double>{0.8, 0.9};
   tlag[0] = std::vector<double>{2.8, 3.9};
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 5e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-6);
@@ -374,32 +374,32 @@ TEST_F(TorstenOneCptTest, ss_constant_infusion) {
   double rel_tol = 1e-12, abs_tol = 1e-12;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 5e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-6);
@@ -417,13 +417,13 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion) {
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f, nCmt,
+  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f_onecpt, nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
                                 0,
                                 rel_tol, abs_tol, max_num_steps);
 
-  MatrixXd x_bdf = torsten::pmx_solve_bdf(f, nCmt,
+  MatrixXd x_bdf = torsten::pmx_solve_bdf(f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
                               pMatrix, biovar, tlag,
                               0,
@@ -448,34 +448,34 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion) {
   rel_tol = 1e-12;
   abs_tol = 1e-12;
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 5e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-3, 1e-4);
 
   biovar[0] = std::vector<double>{0.8, 0.7};
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                                time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                                rel_tol, abs_tol, max_num_steps,
                                2e-5, 1e-10, 1.5e-6, 2e-8);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                                time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                                rel_tol, abs_tol, max_num_steps,
                                2e-5, 1e-10, 1e-6, 1e-8);
@@ -487,13 +487,13 @@ TEST_F(TorstenOneCptTest, multiple_bolus) {
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f, nCmt,
+  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f_onecpt, nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
                                 0,
                                 rel_tol, abs_tol, max_num_steps);
 
-  MatrixXd x_bdf = torsten::pmx_solve_bdf(f, nCmt,
+  MatrixXd x_bdf = torsten::pmx_solve_bdf(f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
                               pMatrix, biovar, tlag,
                               0,
@@ -520,32 +520,32 @@ TEST_F(TorstenOneCptTest, multiple_bolus) {
   ii[0] = 3.5;
   addl[0] = 2;
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-6);
@@ -556,7 +556,7 @@ TEST_F(TorstenOneCptTest, multiple_bolus_tlag_overload) {
   addl[0] = 1;
   tlag[0] = std::vector<double>{2.8, 3.9};
 
-  TORSTEN_ODE_PARAM_OVERLOAD_TEST(torsten::pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_PARAM_OVERLOAD_TEST(torsten::pmx_solve_bdf, f_onecpt, nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                                   1e-10, 1e-10);
 }
@@ -732,13 +732,13 @@ TEST_F(TorstenOneCptTest, multiple_bolus_time_dependent_param) {
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f, nCmt,
+  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f_onecpt, nCmt,
                                          time, amt, rate, ii, evid, cmt, addl, ss,
                                          pMatrix, biovar, tlag,
                                          0,
                                          rel_tol, abs_tol, max_num_steps);
 
-  MatrixXd x_bdf = torsten::pmx_solve_bdf(f, nCmt,
+  MatrixXd x_bdf = torsten::pmx_solve_bdf(f_onecpt, nCmt,
                                        time, amt, rate, ii, evid, cmt, addl, ss,
                                        pMatrix, biovar, tlag,
                                        0,
@@ -763,33 +763,33 @@ TEST_F(TorstenOneCptTest, multiple_bolus_time_dependent_param) {
   rel_tol = 1e-12;
   abs_tol = 1e-12;
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-3, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               1e-5, 1e-6, 5e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-3, 1e-4);
 
   biovar[0] = std::vector<double>{0.8, 0.8};
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-4, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               1e-5, 1e-6, 1e-4, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-4, 1e-6);
@@ -807,13 +807,13 @@ TEST_F(TorstenOneCptTest, rate_par) {
   double rel_tol = 1e-6, abs_tol = 1e-6;
   long int max_num_steps = 1e6;
 
-  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f, nCmt,
+  MatrixXd x_rk45 = torsten::pmx_solve_rk45(f_onecpt, nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar, tlag,
                                   0,
                                   rel_tol, abs_tol, max_num_steps);
 
-  MatrixXd x_bdf = torsten::pmx_solve_bdf(f, nCmt,
+  MatrixXd x_bdf = torsten::pmx_solve_bdf(f_onecpt, nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
                                 0,
@@ -835,40 +835,38 @@ TEST_F(TorstenOneCptTest, rate_par) {
   torsten::test::test_val(xt, x_rk45, 1e-6, 1e-5);
   torsten::test::test_val(xt, x_bdf, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 5e-5, 1e-5, 1e-5);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-4, 1e-5);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 5e-5, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-4, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-6);
 }
 
 TEST_F(TorstenTwoCptTest, rate_par) {
-  auto f = refactor::PMXTwoCptModel<double,double,double,double>::f_;
-
   pMatrix[0][0] = 5;  // CL
   pMatrix[0][1] = 8;  // Q
   pMatrix[0][2] = 35;  // Vc
@@ -882,16 +880,16 @@ TEST_F(TorstenTwoCptTest, rate_par) {
   long int max_num_steps = 1e6;
 
   MatrixXd x_rk45, x_bdf;
-  x_rk45 = pmx_solve_rk45(f2, nCmt,
-                                         time, amt, rate, ii, evid, cmt, addl, ss,
-                                         pMatrix, biovar, tlag,
-                                         0,
-                                         rel_tol, abs_tol, max_num_steps);
-  x_bdf = pmx_solve_bdf(f2, nCmt,
-                                       time, amt, rate, ii, evid, cmt, addl, ss,
-                                       pMatrix, biovar, tlag,
-                                       0,
-                                       rel_tol, abs_tol, max_num_steps);
+  x_rk45 = pmx_solve_rk45(f_twocpt, nCmt,
+                          time, amt, rate, ii, evid, cmt, addl, ss,
+                          pMatrix, biovar, tlag,
+                          0,
+                          rel_tol, abs_tol, max_num_steps);
+  x_bdf = pmx_solve_bdf(f_twocpt, nCmt,
+                        time, amt, rate, ii, evid, cmt, addl, ss,
+                        pMatrix, biovar, tlag,
+                        0,
+                        rel_tol, abs_tol, max_num_steps);
 
   MatrixXd amounts(10, 3);
   amounts << 0.00000,   0.00000,   0.0000000,
@@ -911,32 +909,32 @@ TEST_F(TorstenTwoCptTest, rate_par) {
   expect_near_matrix_eq(xt, x_rk45, rel_err_rk45);
   expect_near_matrix_eq(xt, x_bdf, rel_err_bdf);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_rk45, f_twocpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 4e-5, 1e-3, 1e-4);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_bdf, f_twocpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-2, 5e-4);
 
-  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_THETA_TEST(pmx_solve_adams, f_twocpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-4, 1e-4, 1e-5);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_rk45, f_twocpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 5e-5, 1e-6, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_bdf, f_twocpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-4, 1e-6);
 
-  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_BIOVAR_TEST(pmx_solve_adams, f_twocpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-6);
@@ -1037,10 +1035,9 @@ TEST_F(TorstenOdeTest, exception) {
   pMatrix[0][3] = 1.0E+80;
   pMatrix[0][4] = 1.0E+70;
 
-  auto& f = refactor::PMXTwoCptModel<double, double, double, double>::f_;
   int ncmt = refactor::PMXTwoCptModel<double, double, double, double>::Ncmt;
 
-  EXPECT_NO_THROW(torsten::pmx_solve_bdf(f, ncmt, time, amt, rate, ii,
+  EXPECT_NO_THROW(torsten::pmx_solve_bdf(f_twocpt, ncmt, time, amt, rate, ii,
                                                evid, cmt, addl, ss, pMatrix,
                                                biovar, tlag));
 }
@@ -1089,17 +1086,17 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_rate) {
   long int max_num_steps = 1e8;
   biovar[0] = std::vector<double>{0.8, 0.7};
 
-  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              1e-3, 1e-6, 1e-5, 1e-6);
 
-  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              1e-3, 1e-10, 1e-4, 2e-8);
 
-  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_adams, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              1e-3, 1e-8, 1e-5, 1e-8);
@@ -1124,14 +1121,14 @@ TEST_F(TorstenOneCptTest, multiple_infusion_rate) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-6, 1e-3, 1e-5);
 
   amt[0] = 0;
   amt[1] = 0;
-  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              2e-5, 1e-6, 1e-3, 1e-5);
@@ -1158,17 +1155,17 @@ TEST_F(TorstenOneCptTest, multiple_infusion_amt) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                             time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                             rel_tol, abs_tol, max_num_steps,
                             2e-5, 1e-6, 1e-4, 1e-5);
 
-  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                             time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                             rel_tol, abs_tol, max_num_steps,
                             2e-5, 1e-6, 1e-4, 1e-5);
 
-  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_adams, f_onecpt, nCmt,
                             time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                             rel_tol, abs_tol, max_num_steps,
                             2e-5, 1e-6, 1e-4, 1e-5);
@@ -1193,17 +1190,17 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_amt) {
   long int max_num_steps = 1e8;
   biovar[0] = std::vector<double>{0.8, 0.7};
 
-  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_rk45, f, nCmt,
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_rk45, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              1e-3, 1e-6, 1e-5, 1e-6);
 
-  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              1e-3, 1e-10, 1e-4, 2e-8);
 
-  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_adams, f, nCmt,
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_adams, f_onecpt, nCmt,
                              time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                              rel_tol, abs_tol, max_num_steps,
                              1e-3, 1e-8, 1e-5, 1e-8);
@@ -1268,7 +1265,7 @@ TEST_F(TorstenOneCptTest, multiple_infusion_time) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 1e-5);
@@ -1293,7 +1290,7 @@ TEST_F(TorstenOneCptTest, multiple_bolus_time) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 5e-5, 1e-5);
@@ -1323,7 +1320,7 @@ TEST_F(TorstenOneCptTest, ss_multiple_infusion_time) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 5e-5, 1e-5);
@@ -1354,7 +1351,7 @@ TEST_F(TorstenOneCptTest, ss_multiple_bolus_time) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_TIME_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                               rel_tol, abs_tol, max_num_steps,
                               2e-5, 1e-6, 1e-5, 9e-5);
@@ -1379,8 +1376,90 @@ TEST_F(TorstenOneCptTest, ss_multiple_bolus_ii) {
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
 
-  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_bdf, f, nCmt,
+  TORSTEN_ODE_GRAD_II_TEST(pmx_solve_bdf, f_onecpt, nCmt,
                            time, amt, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
                            rel_tol, abs_tol, max_num_steps,
                            2e-5, 1e-6, 1e-6, 1e-8);
+}
+
+TEST_F(TorstenTwoCptTest, multiple_infusion_amt_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 10.0;
+  resize(3);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  rate[0] = 30;
+  rate[1] = 30;
+  rate[2] = 20;
+  addl[0] = 0;
+  ss[0] = 0;
+  addl[0] = 0;
+  ii[0] = 0;
+  cmt[0] = 1;
+  cmt[1] = 2;
+  cmt[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  {
+    std::vector<var> amt_var(amt.begin(), amt.end());
+    TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f_twocpt, nCmt,
+                               time, amt_var, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                               rel_tol, abs_tol, max_num_steps,
+                               2e-5, 1e-6, 1e-3, 1e-5);
+  }
+
+
+  amt[0] = 0;
+  amt[1] = 0;
+  {
+    std::vector<var> amt_var(amt.begin(), amt.end());
+    TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_bdf, f_twocpt, nCmt,
+                               time, amt_var, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                               rel_tol, abs_tol, max_num_steps,
+                               2e-5, 1e-6, 1e-3, 1e-5);
+  }
+}
+
+TEST_F(TorstenTwoCptTest, ss_multiple_infusion_amt_rate) {
+  time[0] = 0.0;
+  time[1] = 5.0;
+  time[2] = 10.0;
+  resize(3);
+
+  amt[0] = 1200;
+  amt[1] = 800;
+  amt[2] = 800;
+  rate[0] = 380;
+  rate[1] = 380;
+  rate[2] = 480;
+  addl[0] = 0;
+  ss[0] = 1;
+  ss[1] = 1;
+  ss[2] = 1;
+  addl[0] = 0;
+  ii[0] = 4;
+  ii[1] = 4;
+  ii[2] = 4;
+  cmt[0] = 1;
+  cmt[1] = 2;
+  cmt[2] = 1;
+
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+
+  std::vector<var> amt_var(amt.begin(), amt.end());
+  TORSTEN_ODE_GRAD_RATE_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                             time, amt_var, rate, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                             rel_tol, abs_tol, max_num_steps,
+                             2e-5, 1e-6, 1e-3, 1e-5);
+
+  std::vector<var> rate_var(rate.begin(), rate.end());
+  TORSTEN_ODE_GRAD_AMT_TEST(pmx_solve_adams, f_twocpt, nCmt,
+                            time, amt, rate_var, ii, evid, cmt, addl, ss, pMatrix, biovar, tlag,
+                            rel_tol, abs_tol, max_num_steps,
+                            2e-5, 1e-6, 1e-3, 1e-5);
 }

--- a/test/unit/math/torsten/pmx_onecpt_model_test.cpp
+++ b/test/unit/math/torsten/pmx_onecpt_model_test.cpp
@@ -108,12 +108,12 @@ TEST_F(TorstenOneCptModelTest, infusion_theta_grad) {
 
   double dt = 2.5;
   
-  auto f1 = [&](std::vector<double>& pars) {
+  auto f1 = [&](const std::vector<double>& pars) {
     using model_t = PMXOneCptModel<double, double, double, double>;
     model_t model(t0, y0, rate, pars[0], pars[1], pars[2]);
     return model.solve(dt);
   };
-  auto f2 = [&](std::vector<var>& pars) {
+  auto f2 = [&](const std::vector<var>& pars) {
     using model_t = PMXOneCptModel<double, double, double, var>;
     model_t model(t0, y0, rate, pars[0], pars[1], pars[2]);
     return model.solve(dt);
@@ -136,10 +136,10 @@ TEST_F(TorstenOneCptModelTest, ss_bolus_amt_grad) {
   double ii = 12.0;
   
   int cmt = 0;
-  auto f1 = [&](std::vector<double>& amt_vec) {
+  auto f1 = [&](const std::vector<double>& amt_vec) {
     return model.solve(amt_vec[0], rate[cmt-1], ii, cmt);
   };
-  auto f2 = [&](std::vector<var>& amt_vec) {
+  auto f2 = [&](const std::vector<var>& amt_vec) {
     return model.solve(amt_vec[0], rate[cmt-1], ii, cmt);
   };
   std::vector<double> amt_vec{1000.0};
@@ -159,10 +159,10 @@ TEST_F(TorstenOneCptModelTest, ss_infusion_rate_grad) {
   double ii = 12.0;
   
   int cmt = 0;
-  auto f1 = [&](std::vector<double>& rate_vec) {
+  auto f1 = [&](const std::vector<double>& rate_vec) {
     return model.solve(amt, rate_vec[0], ii, cmt);
   };
-  auto f2 = [&](std::vector<var>& rate_vec) {
+  auto f2 = [&](const std::vector<var>& rate_vec) {
     return model.solve(amt, rate_vec[0], ii, cmt);
   };
 
@@ -184,7 +184,7 @@ TEST_F(TorstenOneCptModelTest, ss_bolus_grad_vs_long_run_sd) {
   int cmt = 0;
   double ii = 12.0;
   
-  auto f1 = [&](std::vector<double>& amt_vec) {
+  auto f1 = [&](const std::vector<double>& amt_vec) {
     double t = t0;
     Eigen::Matrix<double, -1, 1> y = y0;
     for (int i = 0; i < 100; ++i) {
@@ -202,7 +202,7 @@ TEST_F(TorstenOneCptModelTest, ss_bolus_grad_vs_long_run_sd) {
     y(cmt - 1) -= amt_vec[0];
     return y;
   };
-  auto f2 = [&](std::vector<var>& amt_vec) {
+  auto f2 = [&](const std::vector<var>& amt_vec) {
     return model.solve(amt_vec[0], rate[cmt - 1], ii, cmt);
   };
   std::vector<double> amt_vec{1000.0};

--- a/test/unit/math/torsten/pmx_twocpt_model_test.cpp
+++ b/test/unit/math/torsten/pmx_twocpt_model_test.cpp
@@ -93,12 +93,12 @@ TEST_F(TorstenTwoCptModelTest, infusion_theta_grad) {
 
   double dt = 2.5;
   
-  auto f1 = [&](std::vector<double>& pars) {
+  auto f1 = [&](const std::vector<double>& pars) {
     using model_t = PMXTwoCptModel<double, double, double, double>;
     model_t model(t0, y0, rate, pars[0], pars[1], pars[2], pars[3], pars[4]);
     return model.solve(dt);
   };
-  auto f2 = [&](std::vector<var>& pars) {
+  auto f2 = [&](const std::vector<var>& pars) {
     using model_t = PMXTwoCptModel<double, double, double, var>;
     model_t model(t0, y0, rate, pars[0], pars[1], pars[2], pars[3], pars[4]);
     return model.solve(dt);
@@ -123,10 +123,10 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_amt_grad) {
   double ii = 12.5;
   
   int cmt = 0;
-  auto f1 = [&](std::vector<double>& amt_vec) {
+  auto f1 = [&](const std::vector<double>& amt_vec) {
     return model.solve(amt_vec[0], rate[cmt-1], ii, cmt);
   };
-  auto f2 = [&](std::vector<var>& amt_vec) {
+  auto f2 = [&](const std::vector<var>& amt_vec) {
     return model.solve(amt_vec[0], rate[cmt-1], ii, cmt);
   };
   std::vector<double> amt_vec{1000.0};
@@ -148,10 +148,10 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_rate_grad) {
   double ii = 12.5;
   
   int cmt = 0;
-  auto f1 = [&](std::vector<double>& rate_vec) {
+  auto f1 = [&](const std::vector<double>& rate_vec) {
     return model.solve(amt, rate_vec[0], ii, cmt);
   };
-  auto f2 = [&](std::vector<var>& rate_vec) {
+  auto f2 = [&](const std::vector<var>& rate_vec) {
     return model.solve(amt, rate_vec[0], ii, cmt);
   };
   std::vector<double> rate_vec{130.0};
@@ -175,7 +175,7 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_by_long_run_sd_vs_bdf_result) {
   int cmt = 0;
   const double ii = 8.5;
   
-  auto f1 = [&](std::vector<double>& amt_vec) {
+  auto f1 = [&](const std::vector<double>& amt_vec) {
     double t = t0;
     Eigen::Matrix<double, -1, 1> y = y0;
     for (int i = 0; i < 100; ++i) {
@@ -198,7 +198,7 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_by_long_run_sd_vs_bdf_result) {
   const std::vector<double> theta{CL, Q, V2, V3, ka};
   const PMXOdeIntegrator<PkBdf> integrator;
   using ode_model_t = PKODEModel<double, double, double, double, PMXTwoCptODE>;
-  auto f2 = [&](std::vector<double>& amt_vec) {
+  auto f2 = [&](const std::vector<double>& amt_vec) {
     double t = t0;
     Eigen::Matrix<double, -1, 1> y = y0;
     for (int i = 0; i < 100; ++i) {
@@ -251,7 +251,7 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_grad_vs_long_run_sd) {
   double ii = 6.0;
   double amt = 1000;
   
-  auto f1 = [&](std::vector<var>& rate_vec) {
+  auto f1 = [&](const std::vector<var>& rate_vec) {
     var t = t0;
     Eigen::Matrix<var, -1, 1> y = y0;
     var t_infus = amt/rate_vec[cmt - 1];
@@ -273,7 +273,7 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_grad_vs_long_run_sd) {
     return y;
   };
 
-  auto f2 = [&](std::vector<var>& rate_vec) {
+  auto f2 = [&](const std::vector<var>& rate_vec) {
     PMXTwoCptModel<double, double, double, double> model(t0, y0, rate, CL, Q, V2, V3, ka);
     return model.solve(amt, rate_vec[cmt - 1], ii, cmt);
   };
@@ -326,7 +326,7 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_by_long_run_sd_vs_bdf_result) {
   const double ii = 11.9;
   const double amt = 1000;
   
-  auto f1 = [&](std::vector<double>& rate_vec) {
+  auto f1 = [&](const std::vector<double>& rate_vec) {
     double t = t0;
     Eigen::Matrix<double, -1, 1> y = y0;
     double t_infus = amt/rate_vec[cmt - 1];
@@ -352,7 +352,7 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_by_long_run_sd_vs_bdf_result) {
   const std::vector<double> theta{CL, Q, V2, V3, ka};
   const PMXOdeIntegrator<PkBdf> integrator;
   using ode_model_t = refactor::PKODEModel<double, double, double, double, PMXTwoCptODE>;
-  auto f2 = [&](std::vector<double>& rate_vec) {
+  auto f2 = [&](const std::vector<double>& rate_vec) {
     double t = t0;
     Eigen::Matrix<double, -1, 1> y = y0;
     double t_infus = amt/rate_vec[cmt - 1];
@@ -411,7 +411,7 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_grad_by_long_run_sd_vs_bdf_result) {
   const double ii = 11.9;
   const double amt = 1000;
   
-  auto f1 = [&](std::vector<var>& rate_vec) {
+  auto f1 = [&](const std::vector<var>& rate_vec) {
     var t = t0;
     Eigen::Matrix<var, -1, 1> y = y0;
     var t_infus = amt/rate_vec[cmt - 1];
@@ -437,7 +437,7 @@ TEST_F(TorstenTwoCptModelTest, ss_infusion_grad_by_long_run_sd_vs_bdf_result) {
   const std::vector<double> theta{CL, Q, V2, V3, ka};
   const PMXOdeIntegrator<PkBdf> integrator;
   using ode_model_t = refactor::PKODEModel<var, var, var, double, PMXTwoCptODE>;
-  auto f2 = [&](std::vector<var>& rate_vec) {
+  auto f2 = [&](const std::vector<var>& rate_vec) {
     var t = t0;
     Eigen::Matrix<var, -1, 1> y = y0;
     var t_infus = amt/rate_vec[cmt - 1];
@@ -499,7 +499,7 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_grad_by_long_run_sd_vs_bdf_result) {
   int cmt = 0;
   const double ii = 11.9;
   
-  auto f1 = [&](std::vector<var>& amt_vec) {
+  auto f1 = [&](const std::vector<var>& amt_vec) {
     double t = t0;
     Eigen::Matrix<var, -1, 1> y = y0;
     for (int i = 0; i < 50; ++i) {
@@ -522,7 +522,7 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_grad_by_long_run_sd_vs_bdf_result) {
   const std::vector<double> theta{CL, Q, V2, V3, ka};
   const PMXOdeIntegrator<PkBdf> integrator;
   using ode_model_t = refactor::PKODEModel<double, var, double, double, PMXTwoCptODE>;
-  auto f2 = [&](std::vector<var>& amt_vec) {
+  auto f2 = [&](const std::vector<var>& amt_vec) {
     double t = t0;
     Eigen::Matrix<var, -1, 1> y = y0;
     for (int i = 0; i < 50; ++i) {
@@ -574,7 +574,7 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_grad_vs_long_run_sd) {
   int cmt = 0;
   double ii = 11.9;
   
-  auto f1 = [&](std::vector<var>& amt_vec) {
+  auto f1 = [&](const std::vector<var>& amt_vec) {
     double t = t0;
     Eigen::Matrix<var, -1, 1> y = y0;
     for (int i = 0; i < 100; ++i) {
@@ -593,7 +593,7 @@ TEST_F(TorstenTwoCptModelTest, ss_bolus_grad_vs_long_run_sd) {
     return y;
   };
 
-  auto f2 = [&](std::vector<var>& amt_vec) {
+  auto f2 = [&](const std::vector<var>& amt_vec) {
     PMXTwoCptModel<double, double, double, double> model(t0, y0, rate, CL, Q, V2, V3, ka);
     return model.solve(amt_vec[0], rate[cmt - 1], ii, cmt);
   };

--- a/test/unit/math/torsten/test_util.hpp
+++ b/test/unit/math/torsten/test_util.hpp
@@ -1325,4 +1325,18 @@ namespace torsten {
     torsten::test::test_grad(f1, f2, TIME, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                       \
   }
 
+#define TORSTEN_ODE_GRAD_II_TEST(FUN, F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG,     \
+                                   RTOL, ATOL, NSTEP,                                                             \
+                                    H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                               \
+   {                                                                                                              \
+     auto f1 = [&] (std::vector<double>& x) {                                                                     \
+       return FUN(F, NCMT, TIME, AMT, RATE, x, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);   \
+     };                                                                                                           \
+     auto f2 = [&] (std::vector<stan::math::var>& x) {                                                            \
+       return FUN(F, NCMT, TIME, AMT, RATE, x, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);   \
+     };                                                                                                           \
+     torsten::test::test_grad(f1, f2, II, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                        \
+   }
+
+
 #endif

--- a/test/unit/math/torsten/test_util.hpp
+++ b/test/unit/math/torsten/test_util.hpp
@@ -3,7 +3,7 @@
 
 #include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/rev/mat.hpp>
-#include <stan/math/prim/mat/functor/finite_diff_gradient.hpp>
+#include <stan/math/torsten/finite_diff_gradient.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/arr/functor/harmonic_oscillator.hpp>
 #include <test/unit/math/prim/arr/functor/lorenz.hpp>
@@ -727,10 +727,11 @@ namespace torsten {
                    double h,
                    double fval_eps,
                    double r_sens_eps,  double a_sens_eps) {
+      using stan::math::value_of;
       std::vector<stan::math::var> theta_v(stan::math::to_var(theta));
       std::vector<double> theta_1(theta), theta_2(theta);
 
-      Eigen::MatrixXd fd = f1(theta);
+      auto fd = f1(theta);
       Eigen::Matrix<stan::math::var, -1, -1> fv = f2(theta_v);
 
       EXPECT_EQ(fd.rows(), fv.rows());
@@ -740,20 +741,14 @@ namespace torsten {
       for (int k = 0; k < fv.size(); ++k) {
         stan::math::set_zero_all_adjoints();
         fv(k).grad(theta_v, g);
-        const Eigen::Matrix<double, -1, 1> theta_x = stan::math::to_vector(theta);
-        auto f = [&f1, &k](const Eigen::Matrix<double, -1, 1>& x) {
-          std::vector<double> x_arr = stan::math::to_array_1d(x);
-          return f1(x_arr)(k);
-        };
-        double fx;
-        Eigen::Matrix<double, -1, 1> g_fd(g.size());
-        stan::math::finite_diff_gradient(f, theta_x, fx, g_fd, h);
-        EXPECT_NEAR(fv(k).val(), fx, fval_eps);
+        auto g_fd = torsten::finite_diff_gradient(f1, theta, k, h);
+        auto fx = fd(k);
+        EXPECT_NEAR(fv(k).val(), value_of(fx), fval_eps);
         for (size_t i = 0; i < g.size(); ++i) {
-          if (abs(g[i]) < 1e-4 || abs(g_fd(i)) < 1e-4) {
-            EXPECT_NEAR(g[i], g_fd(i), a_sens_eps);
+          if (abs(g[i]) < 1e-4 || abs(g_fd[i]) < 1e-4) {
+            EXPECT_NEAR(g[i], value_of(g_fd[i]), a_sens_eps);
           } else {
-            EXPECT_NEAR(g[i], g_fd(i), r_sens_eps * std::max(abs(g[i]), abs(g_fd(i))));
+            EXPECT_NEAR(g[i], value_of(g_fd[i]), r_sens_eps * std::max(abs(g[i]), abs(value_of(g_fd[i]))));
           }
         }
       }
@@ -1159,10 +1154,10 @@ namespace torsten {
 #define TORSTEN_CPT_GRAD_THETA_TEST(FUN, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                     \
   {                                                                                                     \
-    auto f1 = [&] (std::vector<std::vector<double> >& x) {                                              \
+    auto f1 = [&] (const std::vector<std::vector<double> >& x) {                                        \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, x, BIOVAR, TLAG);                            \
     };                                                                                                  \
-    auto f2 = [&] (std::vector<std::vector<stan::math::var> >& x) {                                     \
+    auto f2 = [&] (const std::vector<std::vector<stan::math::var> >& x) {                               \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, x, BIOVAR, TLAG);                            \
     };                                                                                                  \
     torsten::test::test_grad(f1, f2, THETA, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                            \
@@ -1171,10 +1166,10 @@ namespace torsten {
 #define TORSTEN_LIN_GRAD_THETA_TEST(FUN, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                     \
   {                                                                                                     \
-    auto f1 = [&] (std::vector<Eigen::MatrixXd>& x) {                                                   \
+    auto f1 = [&] (const std::vector<Eigen::MatrixXd>& x) {                                             \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, x, BIOVAR, TLAG);                            \
     };                                                                                                  \
-    auto f2 = [&] (std::vector<stan::math::matrix_v>& x) {                                              \
+    auto f2 = [&] (const std::vector<stan::math::matrix_v>& x) {                                        \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, x, BIOVAR, TLAG);                            \
     };                                                                                                  \
     torsten::test::test_grad(f1, f2, THETA, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                            \
@@ -1183,10 +1178,10 @@ namespace torsten {
 #define TORSTEN_CPT_GRAD_BIOVAR_TEST(FUN, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                      \
   {                                                                                                      \
-    auto f1 = [&] (std::vector<std::vector<double> >& x) {                                               \
+    auto f1 = [&] (const std::vector<std::vector<double> >& x) {                                         \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, x, TLAG);                              \
     };                                                                                                   \
-    auto f2 = [&] (std::vector<std::vector<stan::math::var> >& x) {                                      \
+    auto f2 = [&] (const std::vector<std::vector<stan::math::var> >& x) {                                \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, x, TLAG);                              \
     };                                                                                                   \
     torsten::test::test_grad(f1, f2, BIOVAR, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                            \
@@ -1195,10 +1190,10 @@ namespace torsten {
 #define TORSTEN_CPT_GRAD_TLAG_TEST(FUN, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG,   \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                      \
   {                                                                                                      \
-    auto f1 = [&] (std::vector<std::vector<double> >& x) {                                               \
+    auto f1 = [&] (const std::vector<std::vector<double> >& x) {                                         \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, x);                            \
     };                                                                                                   \
-    auto f2 = [&] (std::vector<std::vector<stan::math::var> >& x) {                                      \
+    auto f2 = [&] (const std::vector<std::vector<stan::math::var> >& x) {                                \
       return FUN(TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, x);                            \
     };                                                                                                   \
     torsten::test::test_grad(f1, f2, TLAG, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                              \
@@ -1207,10 +1202,10 @@ namespace torsten {
 #define TORSTEN_CPT_GRAD_RATE_TEST(FUN, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG,   \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                      \
   {                                                                                                      \
-    auto f1 = [&] (std::vector<double>& x) {                                                             \
+    auto f1 = [&] (const std::vector<double>& x) {                                                       \
       return FUN(TIME, AMT, x, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG);                            \
     };                                                                                                   \
-    auto f2 = [&] (std::vector<stan::math::var>& x) {                                                    \
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {                                              \
       return FUN(TIME, AMT, x, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG);                            \
     };                                                                                                   \
     torsten::test::test_grad(f1, f2, RATE, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                              \
@@ -1250,10 +1245,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                    H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                                \
   {                                                                                                               \
-    auto f1 = [&] (std::vector<std::vector<double> >& x) {                                                        \
+    auto f1 = [&] (const std::vector<std::vector<double> >& x) {                                                  \
       return FUN(F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, x, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);       \
     };                                                                                                            \
-    auto f2 = [&] (std::vector<std::vector<stan::math::var> >& x) {                                               \
+    auto f2 = [&] (const std::vector<std::vector<stan::math::var> >& x) {                                         \
       return FUN(F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, x, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);       \
     };                                                                                                            \
     torsten::test::test_grad(f1, f2, THETA, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                      \
@@ -1263,10 +1258,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                    H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                                \
   {                                                                                                               \
-    auto f1 = [&] (std::vector<std::vector<double> >& x) {                                                        \
+    auto f1 = [&] (const std::vector<std::vector<double> >& x) {                                                  \
       return FUN(F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, x, TLAG, 0, RTOL, ATOL, NSTEP);        \
     };                                                                                                            \
-    auto f2 = [&] (std::vector<std::vector<stan::math::var> >& x) {                                               \
+    auto f2 = [&] (const std::vector<std::vector<stan::math::var> >& x) {                                         \
       return FUN(F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, x, TLAG, 0, RTOL, ATOL, NSTEP);        \
     };                                                                                                            \
     torsten::test::test_grad(f1, f2, BIOVAR, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                     \
@@ -1277,10 +1272,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                    H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                                \
   {                                                                                                               \
-    auto f1 = [&] (std::vector<std::vector<double> >& x) {                                                        \
+    auto f1 = [&] (const std::vector<std::vector<double> >& x) {                                                  \
       return FUN(F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, x, 0, RTOL, ATOL, NSTEP);      \
     };                                                                                                            \
-    auto f2 = [&] (std::vector<std::vector<stan::math::var> >& x) {                                               \
+    auto f2 = [&] (const std::vector<std::vector<stan::math::var> >& x) {                                         \
       return FUN(F, NCMT, TIME, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, x, 0, RTOL, ATOL, NSTEP);      \
     };                                                                                                            \
     torsten::test::test_grad(f1, f2, TLAG, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                       \
@@ -1290,10 +1285,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                               \
   {                                                                                                               \
-    auto f1 = [&] (std::vector<double>& x) {                                                                      \
+    auto f1 = [&] (const std::vector<double>& x) {                                                                \
       return FUN(F, NCMT, TIME, AMT, x, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);      \
     };                                                                                                            \
-    auto f2 = [&] (std::vector<stan::math::var>& x) {                                                             \
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {                                                       \
       return FUN(F, NCMT, TIME, AMT, x, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);      \
     };                                                                                                            \
     torsten::test::test_grad(f1, f2, RATE, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                       \
@@ -1303,10 +1298,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                               \
   {                                                                                                               \
-    auto f1 = [&] (std::vector<double>& x) {                                                                      \
+    auto f1 = [&] (const std::vector<double>& x) {                                                                \
       return FUN(F, NCMT, TIME, x, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);     \
     };                                                                                                            \
-    auto f2 = [&] (std::vector<stan::math::var>& x) {                                                             \
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {                                                       \
       return FUN(F, NCMT, TIME, x, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);     \
     };                                                                                                            \
     torsten::test::test_grad(f1, f2, AMT, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                        \
@@ -1316,10 +1311,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                    H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                                \
   {                                                                                                               \
-    auto f1 = [&] (std::vector<double>& x) {                                                                      \
+    auto f1 = [&] (const std::vector<double>& x) {                                                                \
       return FUN(F, NCMT, x, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);      \
     };                                                                                                            \
-    auto f2 = [&] (std::vector<stan::math::var>& x) {                                                             \
+    auto f2 = [&] (const std::vector<stan::math::var>& x) {                                                       \
       return FUN(F, NCMT, x, AMT, RATE, II, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);      \
     };                                                                                                            \
     torsten::test::test_grad(f1, f2, TIME, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                       \
@@ -1329,10 +1324,10 @@ namespace torsten {
                                    RTOL, ATOL, NSTEP,                                                             \
                                     H, EPS_VAL, EPS_RTOL, EPS_ATOL)                                               \
    {                                                                                                              \
-     auto f1 = [&] (std::vector<double>& x) {                                                                     \
+     auto f1 = [&] (const std::vector<double>& x) {                                                               \
        return FUN(F, NCMT, TIME, AMT, RATE, x, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);   \
      };                                                                                                           \
-     auto f2 = [&] (std::vector<stan::math::var>& x) {                                                            \
+     auto f2 = [&] (const std::vector<stan::math::var>& x) {                                                      \
        return FUN(F, NCMT, TIME, AMT, RATE, x, EVID, CMT, ADDL, SS, THETA, BIOVAR, TLAG, 0, RTOL, ATOL, NSTEP);   \
      };                                                                                                           \
      torsten::test::test_grad(f1, f2, II, H, EPS_VAL, EPS_RTOL, EPS_ATOL);                                        \


### PR DESCRIPTION
## Summary
Address #10 and https://github.com/metrumresearchgroup/Torsten/issues/15
Allow `II`, `AMT`, `RATE` to be parameters in steady state case. The implementation constructs adaptors to original RHS `F` functor to create new functors, along with packing and unpacking of parameters and real data.

## Tests
New unit tests in `pmx_ode_test.cpp`
```bash
TEST_F(TorstenOneCptTest, ss_multiple_infusion_rate) 
TEST_F(TorstenOneCptTest, multiple_infusion_rate) 
TEST_F(TorstenOneCptTest, multiple_infusion_amt) 
TEST_F(TorstenOneCptTest, ss_multiple_infusion_amt) 
TEST_F(TorstenTwoCptTest, multiple_bolus_amt) 
TEST_F(TorstenOneCptTest, multiple_infusion_time) 
TEST_F(TorstenOneCptTest, multiple_bolus_time) 
TEST_F(TorstenOneCptTest, ss_multiple_infusion_time) 
TEST_F(TorstenOneCptTest, ss_multiple_bolus_time) 
TEST_F(TorstenOneCptTest, ss_multiple_bolus_ii) 
TEST_F(TorstenTwoCptTest, multiple_infusion_amt_rate) 
TEST_F(TorstenTwoCptTest, ss_multiple_infusion_amt_rate) 
TEST_F(TorstenTwoCptTest, multiple_infusion_ii_amt_rate) 
TEST_F(TorstenTwoCptTest, ss_multiple_infusion_ii_amt_rate) 
TEST_F(TorstenTwoCptTest, multiple_bolus_ii_amt_rate) 
TEST_F(TorstenTwoCptTest, ss_multiple_bolus_ii_amt_rate) 
TEST_F(TorstenTwoCptTest, ss_multiple_infusion_ii_amt) 
TEST_F(TorstenTwoCptTest, ss_multiple_bolus_ii_amt) 
TEST_F(TorstenTwoCptTest, ss_multiple_infusion_ii_rate) 
TEST_F(TorstenTwoCptTest, ss_multiple_bolus_ii_rate) 
```

## Side Effects

None
## Checklist

- [ ] Copyright holder: Metrum Research Group
the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
