### PR TITLE
refactor linear interpolation to use std::lower_bound search

### DIFF
--- a/stan/math/torsten/linear_interpolation.hpp
+++ b/stan/math/torsten/linear_interpolation.hpp
@@ -5,6 +5,7 @@
 #include <stan/math/prim/arr.hpp>
 #include <stan/math/prim/arr/err/check_nonzero_size.hpp>
 #include <stan/math/torsten/PKModel/SearchReal.hpp>
+#include <stan/math/torsten/return_type.hpp>
 #include <vector>
 #include <algorithm>
 
@@ -14,8 +15,9 @@ namespace torsten {
    * Return the values of a piecewise linear function at specifed values of the 
    * function argument. The function is specified in terms of a set of x y pairs.
    *
-   * @tparam T0 Type of elements contained in xout array.
-   * @tparam T1 Type of elements contained in y array.
+   * @tparam T0 Type of value to be interpolated
+   * @tparam T1 Type of elements contained in x array.
+   * @tparam T2 Type of elements contained in y array.
    * @param xout Scalar or array of function argument values.
    * @param x Array of x values. Must be in increasing order.
    * @param y Array of y values. Must have same length as x.
@@ -23,16 +25,10 @@ namespace torsten {
    */
 
   template <typename T0, typename T1, typename T2>
-  typename boost::math::tools::promote_args <T0, T1, T2>::type
-  linear_interpolation(const T0& xout,
-                       const std::vector<T1>& x,
-                       const std::vector<T2>& y) {
-    typedef typename boost::math::tools::promote_args <T0, T1, T2>::type
-      scalar;
-    using std::vector;
-    int nx = x.size();
-    scalar yout;
-
+  typename torsten::return_t<T0, T1, T2>::type
+  inline linear_interpolation(const T0& xout,
+                              const std::vector<T1>& x,
+                              const std::vector<T2>& y) {
     stan::math::check_finite("linear_interpolation", "xout", xout);
     stan::math::check_finite("linear_interpolation", "x", x);
     stan::math::check_finite("linear_interpolation", "y", y);
@@ -41,38 +37,30 @@ namespace torsten {
     stan::math::check_ordered("linear_interpolation", "x", x);
     stan::math::check_matching_sizes("linear_interpolation", "x", x, "y", y);
 
-    if (xout <= x.front()) {
+    typename torsten::return_t<T0, T1, T2>::type yout;
+    if (xout < x.front()) {
       yout = y.front();
-    } else if (xout >= x.back()) {
+    } else if (xout > x.back()) {
       yout = y.back();
     } else {
-      int i = SearchReal(x, nx, xout) - 1;
-      yout = y[i] + (y[i+1] - y[i]) / (x[i+1] - x[i]) * (xout - x[i]);
+      int i = std::lower_bound(x.begin(), x.end(), xout) - x.begin() - 1;
+      yout = y.at(i) + (y.at(i+1) - y.at(i)) / (x.at(i+1) - x.at(i)) * (xout - x.at(i));
     }
-
     return yout;
   }
 
   template <typename T0, typename T1, typename T2>
-  std::vector <typename boost::math::tools::promote_args <T0, T1, T2>::type>
-  linear_interpolation(const std::vector<T0>& xout,
-                       const std::vector<T1>& x,
-                       const std::vector<T2>& y) {
-    typedef typename boost::math::tools::promote_args <T0, T1, T2>::type
-      scalar;
-    using std::vector;
-
-    int nxout = xout.size();
-    vector<scalar> yout(nxout);
-
+  std::vector<typename torsten::return_t<T0, T1, T2>::type>
+  inline linear_interpolation(const std::vector<T0>& xout,
+                              const std::vector<T1>& x,
+                              const std::vector<T2>& y) {
     stan::math::check_nonzero_size("linear_interpolation", "xout", xout);
     stan::math::check_finite("linear_interpolation", "xout", xout);
 
-    for (int i = 0; i < nxout; i++) {
-      yout[i] = linear_interpolation(xout[i], x, y);
-    }
+    std::vector<typename torsten::return_t<T0, T1, T2>::type> yout(xout.size());
+    std::transform(xout.begin(), xout.end(), yout.begin(),
+                   [&x, &y](const T0& xi) { return linear_interpolation(xi, x, y); });
     return yout;
   }
-
 }
 #endif


### PR DESCRIPTION
## Summary
Simplify `linear_interpolation` implementation by using `lower_bound` to search the interpolation interval.

## Tests
Pass old tests and new unit tests
```c++
TEST(linear_interpolation, xdbl)
TEST(linear_interpolation, in_range_gradient_x_y)
TEST(linear_interpolation, out_range_gradient_x_y)
```

## Side Effects
None

## Checklist

- [x] Math issue #(issue number)

- [x] Copyright holder: Metrum Research Group. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Code-Quality) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
