### PR TITLE
bugfix: allow ka=0 in one/two compartment models

### DIFF
--- a/test/unit/math/torsten/pmx_onecpt_model_test.cpp
+++ b/test/unit/math/torsten/pmx_onecpt_model_test.cpp
@@ -14,6 +14,20 @@ using torsten::pmx_integrate_ode_bdf;
 using refactor::PMXOneCptODE;
 using refactor::PMXOdeFunctorRateAdaptor;
 
+TEST_F(TorstenOneCptModelTest, ka_zero) {
+  y0(0) = 745;
+  y0(1) = 100;
+  rate[0] = 1200;
+  rate[1] = 200;
+  ka = 0.0;
+  using model_t = PMXOneCptModel<double, double, double, double>;
+  model_t model(t0, y0, rate, CL, V2, ka);
+  std::vector<double> yvec(y0.data(), y0.data() + y0.size());
+  auto y = model.solve(ts[0]);
+  EXPECT_FLOAT_EQ(y(0), 865.0);
+  EXPECT_FLOAT_EQ(y(1), 113.32912);
+}
+
 TEST_F(TorstenOneCptModelTest, rate_dbl) {
   rate[0] = 1200;
   rate[1] = 200;

--- a/test/unit/math/torsten/pmx_twocpt_model_test.cpp
+++ b/test/unit/math/torsten/pmx_twocpt_model_test.cpp
@@ -15,6 +15,22 @@ using stan::math::integrate_ode_bdf;
 using refactor::PMXTwoCptODE;
 using refactor::PMXOdeFunctorRateAdaptor;
 
+TEST_F(TorstenTwoCptModelTest, ka_zero) {
+  y0(0) = 745;
+  y0(1) = 100;
+  y0(2) = 130;  
+  rate[0] = 1200;
+  rate[1] = 200;
+  rate[2] = 300;
+  ka = 0.0;
+  using model_t = PMXTwoCptModel<double, double, double, double>;
+  model_t model(t0, y0, rate, CL, Q, V2, V3, ka);
+  auto y = model.solve(ts[0]);
+  EXPECT_FLOAT_EQ(y(0), 865.0);
+  EXPECT_FLOAT_EQ(y(1), 120.52635);
+  EXPECT_FLOAT_EQ(y(2), 158.09552);
+}
+
 TEST_F(TorstenTwoCptModelTest, rate_dbl) {
   rate[0] = 1200;
   rate[1] = 200;


### PR DESCRIPTION
Address issue #37 .
When `ka=0`, GUT compartment should accumulate doses(if there is any), and central compartment receives no contribution from GUT.

Added:
- conditioning on `ka > 0` for previous implementations.
- when `! ka > 0`, GUT compartment `y(0) = y0 + rate * dt`.
- replace `check_positive_finite` on `ka` with `check_finite` and `check_nonnegative`
- for steady-state `ka` must be positive.